### PR TITLE
use PositionRetainedScrollPhysics

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ and the Flutter guide for
 - [x] ListWheelScrollView
 - [ ] NestedScrollView (waiting testing)
 
-3. Using `RetainableScrollController` to retain the old offset to avoid scrolling when adding new items into the top of `ListView`. See [retain old scroll offset](#using-retainablescrollcontroller-for-retaining-the-old-scroll-offset).
+3. Using `PositionRetainedScrollPhysics` to retain the old offset to avoid scrolling when adding new items into the top of `ListView`. See [retain old scroll offset](#using-positionretainedscrollphysics-for-retaining-the-old-scroll-offset).
 
 4. Check if the specific `index` is visible on the screen. See [check visibility](#checking-index-is-visible-on-the-screen).
 
@@ -156,36 +156,20 @@ By invoking `YourObserver.isRevealed` to check if the `index`'s `RenderObject` i
 
 More details, see [API reference](https://pub.dev/documentation/positioned_scroll_observer/latest/positioned_scroll_observer/SliverScrollObserver/isRevealed.html).
 
-### Using `RetainableScrollController` for retaining the old scroll offset
+### Using `PositionRetainedScrollPhysics` for retaining the old scroll offset
 
 <div> 
     <img src="https://github.com/SimonWang9610/indexed_scroll_observer/blob/main/snapshots/retain.gif?raw=true" width="320">
 </div>
 
-1. create a `RetainableScrollController`
-
 ```dart
-  final RetainableScrollController _controller = RetainableScrollController();
-```
-
-2. using it when you do not want the list to scroll if inserting a new item at `0` index
-
-```dart
-    _items.insert(
-      0,
-      ObserverProxy(
-        observer: _observer,
-        child: ListTile(
-          leading: const CircleAvatar(
-            child: Text("L"),
-          ),
-          title: Text("Positioned List Example $_itemCount"),
-        ),
-      ),
-    );
-    _controller.retainOffset();
-
-    setState(() {});
+ListView.builder(
+  controller: _controller,
+  reverse: true,
+  physics: const PositionRetainedScrollPhysics(),
+  itemBuilder: (context, index) => _items[index],
+  itemCount: _itemCount,
+);
 ```
 
 ### Pay attention

--- a/example/lib/example/official_list_example.dart
+++ b/example/lib/example/official_list_example.dart
@@ -14,8 +14,7 @@ class OfficialListExample extends StatefulWidget {
 class _OfficialListExampleState extends State<OfficialListExample> {
   int _itemCount = 100;
 
-  // final ScrollController _controller = ScrollController();
-  final RetainableScrollController _controller = RetainableScrollController();
+  final ScrollController _controller = ScrollController();
 
   late final SliverScrollObserver _observer =
       MultiChildSliverObserver(itemCount: _itemCount);
@@ -43,20 +42,6 @@ class _OfficialListExampleState extends State<OfficialListExample> {
 
   @override
   Widget build(BuildContext context) {
-    ListView.builder(
-      controller: _controller,
-      itemBuilder: (context, index) => ObserverProxy(
-        observer: _observer,
-        child: ListTile(
-          key: ValueKey<int>(index),
-          leading: const CircleAvatar(
-            child: Text("L"),
-          ),
-          title: Text("Positioned List Example $index"),
-        ),
-      ),
-      itemCount: _itemCount,
-    );
     return Scaffold(
       appBar: AppBar(
         centerTitle: true,
@@ -105,6 +90,7 @@ class _OfficialListExampleState extends State<OfficialListExample> {
             child: ListView.builder(
               controller: _controller,
               reverse: true,
+              physics: const PositionRetainedScrollPhysics(),
               itemBuilder: (context, index) => _items[index],
               itemCount: _itemCount,
             ),
@@ -141,26 +127,8 @@ class _OfficialListExampleState extends State<OfficialListExample> {
         ),
       ),
     );
-    _checkScrollOffset();
-    // _observer.standBy(_controller.position);
-    _controller.retainOffset();
 
     setState(() {});
-
-    final double old = _controller.position.pixels;
-    final double oldMax = _controller.position.maxScrollExtent;
-
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      _checkScrollOffset();
-
-      // if (old > 0.0) {
-      //   final diff = _controller.position.maxScrollExtent - oldMax;
-      //   _controller.jumpTo(old + diff);
-      //   final current = _controller.position.pixels;
-      //   final max = _controller.position.maxScrollExtent;
-      //   print("[post frame]: $diff, current: $current, max: $max");
-      // }
-    });
   }
 
   void _deleteItem() {
@@ -169,20 +137,7 @@ class _OfficialListExampleState extends State<OfficialListExample> {
 
     _items.removeLast();
 
-    final double old = _controller.position.pixels;
-    final double oldMax = _controller.position.maxScrollExtent;
-
-    _checkScrollOffset();
     setState(() {});
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      _checkScrollOffset();
-    });
-  }
-
-  void _checkScrollOffset() {
-    final max = _controller.position.maxScrollExtent;
-    final current = _controller.position.pixels;
-    print("current: $current, max: $max");
   }
 }
 


### PR DESCRIPTION
Problem: 
- using `RetainableScrollController` may break developers' existing code implementations 
- and developers have to invoke `RetaibleScrollController.retainOffset()` explicitly to achieve their goals.

Solution:
By deprecating `RetainableScrollController`, we could use `PositionRetainedScrollPhysics` to achieve the same goals, but without introducing breakage into your existing projects. The usage is like below:
```dart
ListView.builder(
  controller: _controller,
  reverse: true,
  physics: const PositionRetainedScrollPhysics(),
  itemBuilder: (context, index) => _items[index],
  itemCount: _itemCount,
);
```
The only thing would change is passing `physics: const PositionRetainedScrollPhysics()` in your `ListView`. Particularly, you could also disable retaining the scroll position by setting `PositionRetainedScrollPhysics.shouldRetain = false`. Besides, it could also be `applyTo` other `ScrollPhysics`.